### PR TITLE
fix: toBN failed for scientific notation argument

### DIFF
--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewPayoutBounty/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewPayoutBounty/index.tsx
@@ -54,7 +54,7 @@ const ReviewPayoutBounty = ({ closeSnackbar, enqueueSnackbar, onClose, onPrev, t
 
     const estimateGas = async () => {
       const web3 = getWeb3()
-      const { asciiToHex, fromWei, padLeft, toBN, toHex } = web3.utils
+      const { asciiToHex, fromWei, padLeft, toBN, toHex, toWei } = web3.utils
 
       let txData = EMPTY_DATA
 
@@ -65,7 +65,7 @@ const ReviewPayoutBounty = ({ closeSnackbar, enqueueSnackbar, onClose, onPrev, t
       const stripHexPrefix = (v) => v.replace('0x', '')
 
       const _getInput = (_address, _amount, _isRepOnly) => {
-        const _amountBN = toBN(_amount * 10 ** 18)
+        const _amountBN = toWei(toBN(_amount))
         const _amountHex = padLeft(
           stripHexPrefix(toHex(_isRepOnly ? _amountBN.add(toBN(1)).toString() : _amountBN.toString())),
           24,


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/leapdao/meta/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

expression `amount * 10 ** 18` may produce a number in 1e20 format and `toBN` will fail. Replaced with `web3.utils.toWei` call. The issue can be observed when entering 1095 DAI
<!-- Concise description of what this PR achieves, including any context. -->

## Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
