### PR TITLE
fix: properly handle non-payment calls to bounty payout contract

### DIFF
--- a/src/logic/tokens/utils/tokenHelpers.ts
+++ b/src/logic/tokens/utils/tokenHelpers.ts
@@ -123,4 +123,7 @@ export const isERC721Contract = async (contractAddress: string): Promise<boolean
   return isERC721
 }
 
-export const isBountyPayoutTransaction = (recipient: string): boolean => recipient === getBountyPayoutContractAddr()
+export const isBountyPayoutTransaction = (to: string, data?: string): boolean =>
+  to === getBountyPayoutContractAddr() &&
+  data &&
+  (data.startsWith('0xfdcdab0b') || data.startsWith('0x4afbda3b') || data.startsWith('0xd89a4076'))

--- a/src/routes/safe/components/Balances/SendModal/screens/PayoutBounty/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/PayoutBounty/index.tsx
@@ -171,15 +171,7 @@ const PayoutBounty = ({ initialValues, onClose, onNext }) => {
                         type="checkbox"
                       />
                       <Paragraph className={classes.checkboxLabel} size="md" weight="bolder">
-                        {'Refund execution tx fee (needs at least 0.1Ξ in the Safe and '}
-                        <a
-                          href="https://github.com/leapdao/meta/blob/master/playbook/keybearers.md"
-                          rel="noopener noreferrer"
-                          target="_blank"
-                        >
-                          new contract
-                        </a>
-                        {' approved)'}
+                        Refund execution tx fee (needs at least 0.1Ξ in the Safe)
                       </Paragraph>
                     </Block>
                   </Col>

--- a/src/routes/safe/components/Balances/SendModal/screens/ReviewPayoutBounty/index.tsx
+++ b/src/routes/safe/components/Balances/SendModal/screens/ReviewPayoutBounty/index.tsx
@@ -47,7 +47,7 @@ const ReviewPayoutBounty = ({ closeSnackbar, enqueueSnackbar, onClose, onPrev, t
   const txToken = tokens.find((token) => token.address === bountyTokenAddr)
   const isSendingETH = false
   // if no refund, use old version of bounty payout contract (mainnet hardcoded)
-  const txRecipient = tx.withRefund ? getBountyPayoutContractAddr() : '0x572d03FD45E85d5ca0BCd3679c99000D23A6b8f1'
+  const txRecipient = getBountyPayoutContractAddr()
 
   useEffect(() => {
     let isCurrent = true

--- a/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
+++ b/src/routes/safe/store/actions/transactions/utils/transactionHelpers.ts
@@ -218,7 +218,7 @@ export const calculateTransactionType = (tx: Transaction): TransactionTypeValues
     txType = TransactionTypes.SETTINGS
   } else if (tx.isCancellationTx) {
     txType = TransactionTypes.CANCELLATION
-  } else if (isBountyPayoutTransaction((tx as any).to)) {
+  } else if (isBountyPayoutTransaction(tx.recipient, tx.data)) {
     txType = TransactionTypes.BOUNTY
   } else if (tx.customTx) {
     txType = TransactionTypes.CUSTOM
@@ -257,7 +257,7 @@ export const buildTx = async ({
   const refundParams = await getRefundParams(tx, getERC20DecimalsAndSymbol)
   const decodedParams = getDecodedParams(tx)
   const confirmations = getConfirmations(tx)
-  const isBountyPayout = isBountyPayoutTransaction(tx.to)
+  const isBountyPayout = isBountyPayoutTransaction(tx.to, tx.data)
 
   let tokenDecimals = 18
   let tokenSymbol = 'ETH'


### PR DESCRIPTION
Please remember the [Contributing Guidelines](https://github.com/leapdao/meta/blob/master/CONTRIBUTION.md) :heart:

## What does this PR do?

bounty payout tx detection code now uses function signature as well. Otherwise the non-payment calls to BountyPayout are not possible (e.g. `addWhitelisted`) 
<!-- Concise description of what this PR achieves, including any context. -->

## Recommendations for testing

<!-- Tips for testing this PR, or anything you want to bring special attention to. -->

## Links to relevant issues or information

<!-- Link to relevant issues, comments, etc. -->
